### PR TITLE
Change how on: :error works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 retryable_ex-*.tar
 
+.elixir_ls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # retryable changes
 
+## 1.1.0
+-----------
+* `on: error` no longer needs to be "wrapped" and considers the following return value shapes to be failures: `:error`, `{:error, reason}`, `{:error, reason, ...}`
+
 ## 1.0.0
 -----------
 * Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # retryable changes
 
-## 1.1.0
+## 2.0.0
 -----------
-* `on: error` no longer needs to be "wrapped" and considers the following return value shapes to be failures: `:error`, `{:error, reason}`, `{:error, reason, ...}`
+* `on: error` no longer needs to be "wrapped" and considers the following return value shapes to be failures: `:error`, `{:error, term}`, `{:error, term, ...}`. The shapes are customizable via a function.
 
 ## 1.0.0
 -----------

--- a/lib/retryable.ex
+++ b/lib/retryable.ex
@@ -112,10 +112,9 @@ defmodule Retryable do
 
   When you use the `[on: error]` option, the following return values will cause a retry:
   * `:error`
-  * `{:error, term}`
-  * `{:error, term1, term2, ...}`
-
-  In other words, `:error` or a tuple where the first element is `:error`.
+  * `{:error, reason}`
+  * `{:error, reason, ...}`
+  * i.e. any tuple where the first element is `:error`
 
   You can customize the shape that defines an error with a function:
   ```elixir
@@ -126,7 +125,13 @@ defmodule Retryable do
     {:failure, _reason} -> true
     _ -> false
   end
-  retryable([on: {:error, error_shape}], fn -> ... end)
+
+  retryable([on: {:error, error_shape}], fn ->
+    case SomeModue.some_function do
+      :failure = result -> result # Will cause retry
+      {:ok, value} = result -> result # Will not cause retry
+    end
+  end)
   ```
 
   ## Examples

--- a/lib/retryable.ex
+++ b/lib/retryable.ex
@@ -172,20 +172,20 @@ defmodule Retryable do
     try do
       func.() |> handle_error(options, func, count)
     rescue
-      e -> handle_exception(e, options, func, count)
+      e -> handle_exception(e, System.stacktrace, options, func, count)
     after
       handle_after(options, count)
     end
   end
 
-  defp handle_exception(e, options, func, count) do
+  defp handle_exception(e, stacktrace, options, func, count) do
     cond do
       count == options[:tries] ->
-        reraise e, System.stacktrace
+        reraise e, stacktrace
       !exception_match?(options, e) ->
-        reraise e, System.stacktrace
+        reraise e, stacktrace
       !message_match?(options, e.message) ->
-        reraise e, System.stacktrace
+        reraise e, stacktrace
       true ->
         sleep(options, count)
         retryable(options, func, count+1)

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Retryable.MixProject do
   defp deps do
     [
       {:mox, "~> 0.3", only: :test},
-      {:ex_doc, "~> 0.18", only: :dev},
+      {:ex_doc, "~> 0.19", only: :dev},
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Retryable.MixProject do
   def project do
     [
       app: :retryable_ex,
-      version: "1.0.0",
+      version: "2.0.0",
       elixir: ">= 1.4.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.2", "6f4081ccd9ed081b6dc0bd5af97a41e87f5554de469e7d76025fba535180565f", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mox": {:hex, :mox, "0.3.1", "2ab1dce006387a91fbe1e727ba468d3e0691eacfd4e2fc7308d53676ec335c46", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
 }

--- a/test/retryable_test.exs
+++ b/test/retryable_test.exs
@@ -72,15 +72,15 @@ defmodule RetryableTest do
 
   test "retries on :error" do
     FooMock
-      |> expect(:foo, fn -> {:error, {:error, "no"}} end)
-      |> expect(:foo, fn -> {:ok, {:ok, "yes"}} end)
+      |> expect(:foo, fn -> {:error, "fail"} end)
+      |> expect(:foo, fn -> {:ok, "success"} end)
 
-    assert {:ok, "yes"} = retryable [on: :error], &FooMock.foo/0
+    assert {:ok, "success"} = retryable [on: :error], &FooMock.foo/0
   end
 
   test "gives up on :error" do
     FooMock
-      |> expect(:foo, 2, fn -> {:error, {:error, "no"}} end)
+      |> expect(:foo, 2, fn -> {:error, "no"} end)
 
     assert {:error, "no"} = retryable [on: :error], &FooMock.foo/0
   end

--- a/test/retryable_test.exs
+++ b/test/retryable_test.exs
@@ -72,11 +72,41 @@ defmodule RetryableTest do
 
   test "retries on :error" do
     FooMock
+      |> expect(:foo, fn -> :error end)
+      |> expect(:foo, fn -> {:ok, "success"} end)
+
+    assert {:ok, "success"} = retryable [on: :error], &FooMock.foo/0
+  end
+
+  test "retries on {:error, reason}" do
+    FooMock
       |> expect(:foo, fn -> {:error, "fail"} end)
       |> expect(:foo, fn -> {:ok, "success"} end)
 
     assert {:ok, "success"} = retryable [on: :error], &FooMock.foo/0
   end
+
+  test "retries on {:error, reason, extra}" do
+    FooMock
+      |> expect(:foo, fn -> {:error, "fail", "extra"} end)
+      |> expect(:foo, fn -> {:ok, "success"} end)
+
+    assert {:ok, "success"} = retryable [on: :error], &FooMock.foo/0
+  end
+
+  test "retries on {:failure, reason}" do
+    FooMock
+      |> expect(:foo, fn -> {:failure, "fail"} end)
+      |> expect(:foo, fn -> {:ok, "success"} end)
+
+    shape = fn
+      {:failure, _} -> true
+      _ -> false
+    end
+
+    assert {:ok, "success"} = retryable [on: {:error, shape}], &FooMock.foo/0
+  end
+
 
   test "gives up on :error" do
     FooMock


### PR DESCRIPTION
A lot of Elixir functions follow the convention of returning `{:error, reason}` on error.

Now, when using the `on: :error` option, retryable_ex will retry functions that return that.

Ex:
```elixir
Retryable.retryable [on: :error], fn ->
  Foo.bar
end
```

If `Foo.bar` returns `{:error, anything}` then it will be retried.

What if `Foo.bar` returns something non-conventional like `{:error, reason, blah}`?

You can customize what matches `on: :error` like so:

```elixir
error_shape = &match?({:error, _reason, _blah}, &1)

Retryable.retryable [on: {:error, error_shape}], fn ->
  Foo.bar
end
```

Or if you don't like function captures or the `match?/2` function:
```elixir
error_shape = fn
  {:error, _reason, _blah} -> true
  _ -> false
end

Retryable.retryable [on: {:error, error_shape}], fn ->
  Foo.bar
end
```